### PR TITLE
listen() should take params by reference and return a bool

### DIFF
--- a/examples/with_lsp_server.rs
+++ b/examples/with_lsp_server.rs
@@ -68,7 +68,9 @@ fn main_loop(
                 eprintln!("got response: {:?}", resp);
             }
             Message::Notification(not) => {
-                documents.listen(not.method.as_str(), not.params.clone());
+                if !documents.listen(not.method.as_str(), &not.params) {
+                    // Add handlers for other types of notifications here.
+                }
             }
         }
     }

--- a/src/text_documents.rs
+++ b/src/text_documents.rs
@@ -103,12 +103,12 @@ impl TextDocuments {
     /// let params = serde_json::to_value("message produced by client").unwrap();
     ///
     /// let mut text_documents = TextDocuments::new();
-    /// text_documents.listen(method, params);
+    /// text_documents.listen(method, &params);
     /// ```
-    pub fn listen(&mut self, method: &str, params: Value) {
+    pub fn listen(&mut self, method: &str, params: &Value) -> bool {
         match method {
             DidOpenTextDocument::METHOD => {
-                let params: DidOpenTextDocumentParams = serde_json::from_value(params)
+                let params: DidOpenTextDocumentParams = serde_json::from_value(params.clone())
                     .expect("Expect receive DidOpenTextDocumentParams");
                 let text_document = params.text_document;
 
@@ -118,9 +118,10 @@ impl TextDocuments {
                     text_document.text,
                 );
                 self.0.insert(text_document.uri, document);
+                true
             }
             DidChangeTextDocument::METHOD => {
-                let params: DidChangeTextDocumentParams = serde_json::from_value(params)
+                let params: DidChangeTextDocumentParams = serde_json::from_value(params.clone())
                     .expect("Expect receive DidChangeTextDocumentParams");
 
                 if let Some(document) = self.0.get_mut(&params.text_document.uri) {
@@ -128,15 +129,18 @@ impl TextDocuments {
                     let version = params.text_document.version;
                     document.update(changes, version);
                 };
+                true
             }
             DidCloseTextDocument::METHOD => {
-                let params: DidCloseTextDocumentParams = serde_json::from_value(params)
+                let params: DidCloseTextDocumentParams = serde_json::from_value(params.clone())
                     .expect("Expect receive DidCloseTextDocumentParams");
 
                 self.0.remove(&params.text_document.uri);
+                true
             }
             _ => {
                 // ignore other request
+                false
             }
         }
     }


### PR DESCRIPTION
listen() should take params by reference and return a bool

This updates `listen()` to take params by reference so, as shown in
the `lsp_server` example, the `clone()` can be deferred until `listen()`
verifies it is going to process the notification based on its `method`.

This also changes `listen()` to return a `bool` to indicate whether the
notification was handled by `listen()`. As shown by the updated example, this
makes it more straightforward to efficiently add logic for other notification
types.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/GiveMe-A-Name/lsp-textdocument/pull/1).
* __->__ #1
