### PR TITLE
remove use of dbg!

### DIFF
--- a/src/text_document.rs
+++ b/src/text_document.rs
@@ -79,7 +79,6 @@ impl FullTextDocument {
                         .map(|&x| x)
                         .collect::<Vec<_>>();
 
-                    dbg!(&self.line_offsets);
                     let diff =
                         (text.len() as i32).saturating_sub_unsigned(end_offset - start_offset);
                     if diff != 0 {


### PR DESCRIPTION
From https://doc.rust-lang.org/std/macro.dbg.html

> The `dbg!` macro works exactly the same in release builds. This is useful when debugging issues that only occur in release builds or when debugging in release mode is significantly faster.
>
> Note that the macro is intended as a debugging tool and therefore you should avoid having uses of it in version control for long periods (other than in tests and similar).