### PR TITLE
canonicalize Position when pointing to location after the newline at the end of a line

### DIFF
--- a/src/text_document.rs
+++ b/src/text_document.rs
@@ -78,15 +78,8 @@ impl FullTextDocument {
                         start.line, start.character, start_offset,
                         end.line, end.character, end_offset
                     );
-                    let (start_slice, end_slice) = (
-                        self.content.get(0..start_offset as usize).unwrap_or(""),
-                        self.content.get(end_offset as usize..).unwrap_or(""),
-                    );
-                    self.content = start_slice
-                        .chars()
-                        .chain(text.chars())
-                        .chain(end_slice.chars())
-                        .collect();
+                    self.content
+                        .replace_range((start_offset as usize)..(end_offset as usize), &text);
 
                     let (start_line, end_line) = (start.line, end.line);
                     assert!(start_line <= end_line);


### PR DESCRIPTION
leverage replace_range to update FullTextDocument::content

This seems more efficient than constructing a completely new String,
particularly when the replacement text is the same length (in bytes)
as the text it is replacing.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/GiveMe-A-Name/lsp-textdocument/pull/30).
* #27
* __->__ #30