### PR TITLE
canonicalize Position when pointing to location after the newline at the end of a line

### DIFF
--- a/src/text_document.rs
+++ b/src/text_document.rs
@@ -146,7 +146,7 @@ impl FullTextDocument {
                 )
             } else {
                 panic!(
-                    "could not determine canonical value for {position:?} in {:?}",
+                    "Could not determine canonical value for {position:?} in {:?}",
                     self.content
                 )
             }


### PR DESCRIPTION
canonicalize Position when pointing to location after the newline at the end of a line

As demonstrated by `test_insert_using_positions_after_newline_at_end_of_line()`,
we were previously updating `line_offsets` incorrectly when a `Position` was
specified such the `character` was beyond the `\n` at the end of a line.

This PR introduces `find_canonical_position()` to "clean up" the `Position`
at the start of `update()` so the computation works reliably. While here, I also
cleaned up the code to use `splice()` to update `self.line_offsets`, which is
more succinct than what was there before.
