### PR TITLE
chore: bump lsp-types/lsp-server versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://github.com/GiveMe-A-Name/lsp-textdocument"
 repository = "https://github.com/GiveMe-A-Name/lsp-textdocument"
 
 [dependencies]
-lsp-types = "0.93.2"
+lsp-types = "0.94.1"
 serde_json = "1.0"
 
 [dev-dependencies]
 anyhow = "1"
-lsp-server = "0.6.0"
+lsp-server = "0.7.2"
 serde = { version = "1.0.147", features = ["derive"] }


### PR DESCRIPTION
I'm doing some dependency updates and these versions are causing conflicts.