### PR TITLE
remove unused unstable feature 'int_roundings'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //!
 //! The text documents [position-encoding](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#positionEncodingKind) only supports `UTF-16`
 
-#![feature(int_roundings)]
 mod text_document;
 mod text_documents;
 

--- a/src/text_document.rs
+++ b/src/text_document.rs
@@ -244,7 +244,7 @@ impl FullTextDocument {
 
         let (mut low, mut high) = (0, line_count);
         while low < high {
-            let mid = (low + high).div_floor(2);
+            let mid = (low + high) / 2;
             if offset
                 > *self
                     .line_offsets


### PR DESCRIPTION
Only the method 'div_floor' was used once. The result is the same as with regular division for unsigned integers.
Without that feature it's possible to use lsp-textdocument on stable rust.