### PR TITLE
Bump lsp-types, lsp-server deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,47 +15,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.0"
+name = "fluent-uri"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "bitflags",
 ]
 
 [[package]]
@@ -66,15 +46,15 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lsp-server"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ea9ae5a5082ca3b6ae824fc7666cd206b99168a4d4c769ad8fe9cc740df6a6"
+checksum = "248f65b78f6db5d8e1b1604b4098a28b43d21a8eb1deeca22b1c421b276c7095"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -95,37 +75,31 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -138,18 +112,18 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -158,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -169,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -180,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -190,49 +164,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "url"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://github.com/GiveMe-A-Name/lsp-textdocument"
 repository = "https://github.com/GiveMe-A-Name/lsp-textdocument"
 
 [dependencies]
-lsp-types = "0.94.1"
+lsp-types = "0.97.0"
 serde_json = "1.0"
 
 [dev-dependencies]
 anyhow = "1"
-lsp-server = "0.7.2"
+lsp-server = "0.7.6"
 serde = { version = "1", features = ["derive"] }

--- a/src/text_documents.rs
+++ b/src/text_documents.rs
@@ -3,13 +3,13 @@ use lsp_types::{
     notification::{
         DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Notification,
     },
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, Range, Url,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, Range, Uri,
 };
 use serde_json::Value;
 use std::collections::BTreeMap;
 
 #[derive(Default)]
-pub struct TextDocuments(BTreeMap<Url, FullTextDocument>);
+pub struct TextDocuments(BTreeMap<Uri, FullTextDocument>);
 
 impl TextDocuments {
     /// Create a text documents
@@ -27,24 +27,24 @@ impl TextDocuments {
         Self(BTreeMap::new())
     }
 
-    pub fn documents(&self) -> &BTreeMap<Url, FullTextDocument> {
+    pub fn documents(&self) -> &BTreeMap<Uri, FullTextDocument> {
         &self.0
     }
 
-    /// Get specify document by giving Url
+    /// Get specify document by giving Uri
     ///
     /// # Examples:
     ///
     /// Basic usage:
     /// ```
     /// use lsp_textdocument::TextDocuments;
-    /// use lsp_types::Url;
+    /// use lsp_types::Uri;
     ///
     /// let text_documents = TextDocuments::new();
-    /// let uri:Url = "file://example.txt".parse().unwrap();
+    /// let uri:Uri = "file://example.txt".parse().unwrap();
     /// text_documents.get_document(&uri);
     /// ```
-    pub fn get_document(&self, uri: &Url) -> Option<&FullTextDocument> {
+    pub fn get_document(&self, uri: &Uri) -> Option<&FullTextDocument> {
         self.0.get(uri)
     }
 
@@ -55,9 +55,9 @@ impl TextDocuments {
     /// Basic usage:
     /// ```no_run
     /// use lsp_textdocument::TextDocuments;
-    /// use lsp_types::{Url, Range, Position};
+    /// use lsp_types::{Uri, Range, Position};
     ///
-    /// let uri: Url = "file://example.txt".parse().unwrap();
+    /// let uri: Uri = "file://example.txt".parse().unwrap();
     /// let text_documents = TextDocuments::new();
     ///
     /// // get document all content
@@ -70,25 +70,25 @@ impl TextDocuments {
     /// let sub_content = text_documents.get_document_content(&uri, Some(range));
     /// assert_eq!(sub_content, Some("ello rus"));
     /// ```
-    pub fn get_document_content(&self, uri: &Url, range: Option<Range>) -> Option<&str> {
+    pub fn get_document_content(&self, uri: &Uri, range: Option<Range>) -> Option<&str> {
         self.0.get(uri).map(|document| document.get_content(range))
     }
 
-    /// Get specify document's language by giving Url
+    /// Get specify document's language by giving Uri
     ///
     /// # Examples
     ///
     /// Basic usage:
     /// ```no_run
     /// use lsp_textdocument::TextDocuments;
-    /// use lsp_types::Url;
+    /// use lsp_types::Uri;
     ///
     /// let text_documents = TextDocuments::new();
-    /// let uri:Url = "file://example.js".parse().unwrap();
+    /// let uri:Uri = "file://example.js".parse().unwrap();
     /// let language =  text_documents.get_document_language(&uri);
     /// assert_eq!(language, Some("javascript"));
     /// ```
-    pub fn get_document_language(&self, uri: &Url) -> Option<&str> {
+    pub fn get_document_language(&self, uri: &Uri) -> Option<&str> {
         self.0.get(uri).map(|document| document.language_id())
     }
 


### PR DESCRIPTION
First of all, thank you so much for this project!

Would it be possible to bump some of the project's dependencies? The `lsp-types` crate added a `#[derive(Hash)]` to its `Location` struct awhile back [here](https://github.com/gluon-lang/lsp-types/pull/279), which I'd like to use to simplify some logic in [asm-lsp](https://github.com/bergercookie/asm-lsp). Versioning conflicts between this crate's dependency on `lsp-types` and the asm-lsp's direct dependence on `lsp-types` made this a bit tricky. 

Thanks again! :)